### PR TITLE
CFE-1098: Fix downstream image build

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/openshift/ansible-operator-plugins
 RUN cd /go/src/github.com/openshift/ansible-operator-plugins \
  && make build
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.17:base
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
@@ -32,10 +32,10 @@ RUN yum install -y \
  && yum clean all \
  && rm -rf /var/cache/yum
 
-COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/build/ansible-operator /usr/local/bin/ansible-operator
-COPY release/ansible/ansible_collections ${HOME}/.ansible/collections/ansible_collections
+COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/ansible-operator /usr/local/bin/ansible-operator
+COPY openshift/release/ansible/ansible_collections ${HOME}/.ansible/collections/ansible_collections
 
-COPY release/ansible/bin /usr/local/bin
+COPY openshift/release/ansible/bin /usr/local/bin
 
 RUN chmod +x /usr/local/bin/user_setup && \
     ./usr/local/bin/user_setup

--- a/openshift/release/ansible/bin/ao-logs
+++ b/openshift/release/ansible/bin/ao-logs
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "WARN: This script is deprecated and will soon be removed"
+
+watch_dir=${1:-/tmp/ansible-operator/runner}
+filename=${2:-stdout}
+mkdir -p ${watch_dir}
+inotifywait -r -m -e close_write ${watch_dir} | while read dir op file
+do
+  if [[ "${file}" = "${filename}" ]] ; then
+    echo "${dir}/${file}"
+    cat ${dir}/${file}
+  fi
+done

--- a/openshift/release/ansible/bin/user_setup
+++ b/openshift/release/ansible/bin/user_setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+mkdir -p "${HOME}/.ansible/tmp"
+chown -R "${USER_UID}:0" "${HOME}"
+chmod -R ug+rwx "${HOME}"
+
+# no need for this script to remain in the image after running
+rm "$0"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

- Update the build image tag to use `rhel-9-release-golang-1.22-openshift-4.17`
- Remove unnecessary use of `build`  dir
- Copy `openshift/release/ansible/bin/ao-logs` and `openshift/release/ansible/bin/user_setup` from https://github.com/openshift/ocp-release-operator-sdk/tree/release-4.16/release/ansible/bin
- Add artifacts from `openshift/` dir in Dockerfile

**Motivation for the change:**
Downstream image should build


