### PR TITLE
CFE-1098: UPSTREAM: <carry>: Use RHEL8 for downstream image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-8-release-golang-1.22-openshift-4.17

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
 
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update builder to use `rhel-8-golang-1.22-openshift-4.17` to fix `GLIBC` version issue. 

**Motivation for the change:**
builder and base image should use same RHEL version.

https://issues.redhat.com/browse/CFE-1098

- Release config changes : https://github.com/openshift/release/pull/55390

