### PR TITLE
CFE-1108: Use upstream e2e to run using downstream images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,12 @@ test-e2e-teardown: $(KIND)
 $(e2e_targets):: test-e2e-setup
 test-e2e:: $(e2e_tests) ## Run e2e tests
 
-test-e2e-ansible:: image/ansible-operator ## Run Ansible e2e tests
+test-e2e-ansible:: image/ansible-operator test-e2e-ansible-run ## Run Ansible e2e tests
+
+.PHONY: test-e2e-ansible-run
+test-e2e-ansible-run:
 	go test ./test/e2e/ansible -v -ginkgo.v
+
 test-e2e-ansible-molecule:: install dev-install image/ansible-operator ## Run molecule-based Ansible e2e tests
 	go run ./hack/generate/samples/molecule/generate.go
 	./hack/tests/e2e-ansible-molecule.sh

--- a/hack/generate/samples/ansible/constants.go
+++ b/hack/generate/samples/ansible/constants.go
@@ -518,6 +518,25 @@ const rolesForBaseOperator = `
       - watch
 #+kubebuilder:scaffold:rules
 `
+const rolesForProject = `
+  ##
+  ## Apply customize roles related to project.openshift.io
+  ##
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projectrequests
+      - projects
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+#+kubebuilder:scaffold:rules
+`
 
 const customMetricsTest = `
 - name: Search for all running pods

--- a/hack/generate/samples/ansible/generate.go
+++ b/hack/generate/samples/ansible/generate.go
@@ -41,6 +41,8 @@ var memcachedGVK = schema.GroupVersionKind{
 	Kind:    "Memcached",
 }
 
+var skipSecretGeneration = ""
+
 func getCli() *cli.CLI {
 	ansibleBundle, _ := plugin.NewBundleWithOptions(
 		plugin.WithName(golang.DefaultNameQualifier),
@@ -127,21 +129,26 @@ func GenerateMoleculeSample(samplesPath string) []sample.Sample {
 	)
 	pkg.CheckError("attempting to create sample cli", err)
 
-	addIgnore, err := samplecli.NewCliSample(
-		samplecli.WithCLI(getCli()),
-		samplecli.WithCommandContext(ansibleMoleculeMemcached.CommandContext()),
-		samplecli.WithGvk(
-			schema.GroupVersionKind{
-				Group:   "ignore",
-				Version: "v1",
-				Kind:    "Secret",
-			},
-		),
-		samplecli.WithPlugins("ansible"),
-		samplecli.WithExtraApiOptions("--generate-role"),
-		samplecli.WithName(ansibleMoleculeMemcached.Name()),
-	)
-	pkg.CheckError("creating ignore samples", err)
+	skipSecretGeneration = os.Getenv("SKIP_SECRET_GENERATION")
+	var addIgnore sample.Sample
+
+	if skipSecretGeneration == "" {
+		addIgnore, err = samplecli.NewCliSample(
+			samplecli.WithCLI(getCli()),
+			samplecli.WithCommandContext(ansibleMoleculeMemcached.CommandContext()),
+			samplecli.WithGvk(
+				schema.GroupVersionKind{
+					Group:   "ignore",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			),
+			samplecli.WithPlugins("ansible"),
+			samplecli.WithExtraApiOptions("--generate-role"),
+			samplecli.WithName(ansibleMoleculeMemcached.Name()),
+		)
+		pkg.CheckError("creating ignore samples", err)
+	}
 
 	// remove sample directory if it already exists
 	err = os.RemoveAll(ansibleMoleculeMemcached.Dir())
@@ -158,9 +165,11 @@ func GenerateMoleculeSample(samplesPath string) []sample.Sample {
 	err = e2e.AllowProjectBeMultiGroup(ansibleMoleculeMemcached)
 	pkg.CheckError("updating PROJECT file", err)
 
-	ignoreGen := sample.NewGenerator(sample.WithNoInit(), sample.WithNoWebhook())
-	err = ignoreGen.GenerateSamples(addIgnore)
-	pkg.CheckError("generating ansible molecule sample - ignore", err)
+	if skipSecretGeneration == "" {
+		ignoreGen := sample.NewGenerator(sample.WithNoInit(), sample.WithNoWebhook())
+		err = ignoreGen.GenerateSamples(addIgnore)
+		pkg.CheckError("generating ansible molecule sample - ignore", err)
+	}
 
 	ImplementMemcached(ansibleMoleculeMemcached, bundleImage)
 

--- a/openshift/Dockerfile.e2e-ansible
+++ b/openshift/Dockerfile.e2e-ansible
@@ -1,0 +1,20 @@
+FROM basebuilder AS builder
+
+COPY . /go/src/github.com/openshift/ansible-operator-plugins
+
+ENV SKIP_SECRET_GENERATION=true
+
+RUN cd /go/src/github.com/openshift/ansible-operator-plugins && \
+  make generate
+
+FROM openshift-ansible-operator-plugins
+
+COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/testdata/memcached-molecule-operator/requirements.yml ${HOME}/requirements.yml
+
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
+
+COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/testdata/memcached-molecule-operator/watches.yaml ${HOME}/watches.yaml
+COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/testdata/memcached-molecule-operator/roles/ ${HOME}/roles/
+COPY --from=builder /go/src/github.com/openshift/ansible-operator-plugins/testdata/memcached-molecule-operator/playbooks/ ${HOME}/playbooks/
+

--- a/test/e2e/ansible/cluster_test.go
+++ b/test/e2e/ansible/cluster_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Running ansible projects", func() {
 			Expect(metrics.CleanUpMetrics(kctl, metricsClusterRoleBindingName)).To(Succeed())
 
 			By("cleaning up created API objects during test process")
-			Expect(operator.UndeployOperator(ansibleSample)).To(Succeed())
+			testutils.WrapWarnOutput("", operator.UndeployOperator(ansibleSample))
 
 			By("ensuring that the namespace was deleted")
 			testutils.WrapWarnOutput(kctl.Wait(false, "namespace", "foo", "--for", "delete", "--timeout", "2m"))

--- a/test/e2e/ansible/local_test.go
+++ b/test/e2e/ansible/local_test.go
@@ -15,6 +15,7 @@
 package e2e_ansible_test
 
 import (
+	"os"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,18 +26,28 @@ import (
 var _ = Describe("Running Ansible projects", func() {
 	Context("built with operator-sdk", func() {
 		BeforeEach(func() {
-			By("Installing CRD's")
-			err := operator.InstallCRDs(ansibleSample)
-			Expect(err).NotTo(HaveOccurred())
+			skip_local_test := os.Getenv("SKIP_LOCAL_TEST")
+			if skip_local_test == "" {
+				By("Installing CRD's")
+				err := operator.InstallCRDs(ansibleSample)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		})
 
 		AfterEach(func() {
-			By("Uninstalling CRD's")
-			err := operator.UninstallCRDs(ansibleSample)
-			Expect(err).NotTo(HaveOccurred())
+			skip_local_test := os.Getenv("SKIP_LOCAL_TEST")
+			if skip_local_test == "" {
+				By("Uninstalling CRD's")
+				err := operator.UninstallCRDs(ansibleSample)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		})
 
 		It("Should run correctly when run locally", func() {
+			skip_local_test := os.Getenv("SKIP_LOCAL_TEST")
+			if skip_local_test != "" {
+				Skip("Skipping local test")
+			}
 			By("Running the project")
 			cmd := exec.Command("make", "run")
 			cmd.Dir = ansibleSample.Dir()

--- a/testdata/memcached-molecule-operator/config/rbac/role.yaml
+++ b/testdata/memcached-molecule-operator/config/rbac/role.yaml
@@ -107,6 +107,23 @@ rules:
       - watch
 
   ##
+  ## Apply customize roles related to project.openshift.io
+  ##
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projectrequests
+      - projects
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+  ##
   ## Apply customize roles for base operator
   ##
   - apiGroups:
@@ -123,4 +140,5 @@ rules:
       - update
       - watch
 #+kubebuilder:scaffold:rules
+
 

--- a/testdata/memcached-molecule-operator/molecule/default/tasks/memcached_test.yml
+++ b/testdata/memcached-molecule-operator/molecule/default/tasks/memcached_test.yml
@@ -56,12 +56,6 @@
       resource_name=custom_resource.metadata.name
     )}}'
 
-# This will verify that the secret role was executed
-- name: Verify that test-service was created
-  assert:
-    that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
-
-
 - name: Verify that project testing-foo was created
   assert:
     that: lookup('k8s', kind='Namespace', api_version='v1', resource_name='testing-foo')
@@ -114,6 +108,12 @@
     that:
       - "'histogram_test_sum 2' in metrics_output.stdout"
 
+
+
+# This will verify that the secret role was executed
+- name: Verify that test-service was created
+  assert:
+    that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
 
 
 - when: molecule_yml.scenario.name == "test-local"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

This PR uses upstream e2e to run using downstream images

**Motivation for the change:**

Add support for running e2e downstream

Corresponding release PR: https://github.com/openshift/release/pull/55440

