### PR TITLE
OCPBUGS-43759: UPSTREAM: <carry>: Set correct upstream ansible-operator version

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -5,7 +5,9 @@ ENV GO111MODULE=on \
 
 COPY . /go/src/github.com/openshift/ansible-operator-plugins
 RUN cd /go/src/github.com/openshift/ansible-operator-plugins \
- && make build
+ && export SIMPLE_VERSION="$(make -pRrq --no-print-directory | grep '^IMAGE_VERSION' | awk -F'= ' '{print $2}')-ocp" \
+ && export GIT_VERSION="$(make -pRrq --no-print-directory | grep '^IMAGE_VERSION' | awk -F'= ' '{print $2}')-ocp" \
+ && make -e build
 
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Set the correct upstream ansible-operator version using the `IMAGE_VERSION` variable from the Makefile.

**Motivation for the change:**
The upstream ansible-operator version got lost during the repo split. It is set using a patch in `openshift/ocp-release-operator-sdk` repo: https://github.com/openshift/ocp-release-operator-sdk/blob/24c01aecd8c0ad1415de3ee2d999a561118b1731/patches/03-setversion.patch

