### PR TITLE
OAPE-192: UPSTREAM: <carry>: Update location from where the Pipfiles are copied in Dockerfile.requirements

### DIFF
--- a/openshift/Dockerfile.requirements
+++ b/openshift/Dockerfile.requirements
@@ -6,7 +6,7 @@ RUN set -e && dnf clean all && rm -rf /var/cache/dnf/* \
   && pushd /usr/local/bin && ln -sf ../../bin/python3.12 python3 && popd \
   && python3 -m ensurepip --upgrade
 
-COPY ./Pipfile* ./
+COPY ./images/ansible-operator/Pipfile* ./
 
 # The build dependencies are required by cachito. Following script
 # does exactly the same. More info at: https://github.com/containerbuildsystem/cachito/blob/master/docs/pip.md#build-dependencies

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -14,16 +14,14 @@ REQUIREMENTS_IMG ?= pip-requirements
 
 .PHONY: build-requirements
 build-requirements:
-	cp ../images/ansible-operator/Pipfile* .
-	$(CONTAINER_ENGINE) build -t $(REQUIREMENTS_IMG) -f Dockerfile.requirements .
-	rm Pipfile*
+	$(CONTAINER_ENGINE) build -t $(REQUIREMENTS_IMG) -f openshift/Dockerfile.requirements .
 
 # Use this target to generate the requirements.txt, requirements-build.txt and requirements-pre-build.txt
 # files using the corresponding Pipfile and Pipfile.lock from the images/ansible-operator directory. The
 # generated files will be used for building the image using cachito in the OSBS environment.
 .PHONY: generate-requirements
 generate-requirements: build-requirements
-	$(CONTAINER_ENGINE) run --rm -it -v .:/tmp/requirements/:Z $(REQUIREMENTS_IMG)
+	$(CONTAINER_ENGINE) run --rm -it -v ./openshift:/tmp/requirements/:Z $(REQUIREMENTS_IMG)
 
 .PHONY: check-requirements
 check-requirements: generate-requirements


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Update the location from where the Pipfile and Pipfile.lock files are copied in Dockerfile.requirements.

**Motivation for the change:**

This change is needed so that even if the context directory used for building the container image is changed from `{ROOT_DIR}/openshift/` to `{ROOT_DIR}/` the image build will not throw any error.

