### PR TITLE
OKD-322: Update install.sh to work on CentOS/RHEL 10

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -29,7 +29,7 @@ RUN dnf clean all && rm -rf /var/cache/dnf/* \
     && pushd /usr/local/bin && ln -sf ../../bin/python3.12 python3 && popd \
     && python3 -m ensurepip --upgrade \
     # python3-six conflicts with pip-installed packages on RHEl/CentOS 10; remove it if present
-    && { dnf remove -y python3-six || true; }
+    && { rpm -q python3-six && dnf remove -y python3-six || true; }
 
 # Add steps for cachito
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"./openshift/"}

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -28,6 +28,7 @@ RUN dnf clean all && rm -rf /var/cache/dnf/* \
     && dnf install -y catatonit python3.12-cryptography python3.12-devel gcc \
     && pushd /usr/local/bin && ln -sf ../../bin/python3.12 python3 && popd \
     && python3 -m ensurepip --upgrade \
+    # python3-six conflicts with pip-installed packages on RHEl/CentOS 10; remove it if present
     && { dnf remove -y python3-six || true; }
 
 # Add steps for cachito

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf clean all && rm -rf /var/cache/dnf/* \
     && dnf update -y \
     && dnf install -y catatonit python3.12-cryptography python3.12-devel gcc \
     && pushd /usr/local/bin && ln -sf ../../bin/python3.12 python3 && popd \
-    && python3 -m ensurepip --upgrade
+    && python3 -m ensurepip --upgrade \
+    && { dnf remove -y python3-six || true; }
 
 # Add steps for cachito
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"./openshift/"}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
removes the dnf package `python3-six` in favor for the pip version

**Motivation for the change:**
In CentOS/RHEL 10 the package `python3-six` is already provided. Pip attempts to uninstall it but it can't as it's a rpm package and it causes a build failure. The way I am testing this is by replacing the base image found [here](https://github.com/openshift/ansible-operator-plugins/blob/d85e7f6a42ded145dc9c3fbd3360cc3e1b0cbedb/openshift/Dockerfile#L12) with a CentOS 10 image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made container image builds more resilient during Python setup so optional packaging issues no longer cause build failures. This reduces intermittent build/deploy errors and improves reliability of deployments and image updates for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->