### PR TITLE
NO-JIRA: [RHCOS10] Migrate base images from UBI9 to UBI10

### DIFF
--- a/.work/compliance/rhcos10/PR2-ubi10-migration.md
+++ b/.work/compliance/rhcos10/PR2-ubi10-migration.md
@@ -1,0 +1,54 @@
+# RHCOS10 UBI10 Migration
+
+## Summary
+
+Migrate all container base images from UBI9/RHEL9 to UBI10/RHEL10 for native RHCOS10 compatibility.
+Also moves the registry from `registry.access.redhat.com` to `registry.redhat.io`.
+
+```text
+registry.access.redhat.com  →  registry.redhat.io
+```
+
+## Image Changes
+
+| Dockerfile                                         | Before                                                              | After                                              |
+| -------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------- |
+| `images/ansible-operator/Dockerfile` (basebuilder) | `registry.access.redhat.com/ubi9/ubi-minimal:9.7`                  | `registry.redhat.io/ubi10/ubi-minimal:10.1`        |
+| `images/ansible-operator/Dockerfile` (base)        | `registry.access.redhat.com/ubi9/ubi-minimal:9.7`                  | `registry.redhat.io/ubi10/ubi-minimal:10.1`        |
+| `images/ansible-operator/pipfile.Dockerfile`       | `registry.access.redhat.com/ubi9/ubi-minimal:9.7`                  | `registry.redhat.io/ubi10/ubi-minimal:10.1`        |
+| `openshift/Dockerfile` (builder)                   | `registry.ci.openshift.org/ocp/builder:rhel-9-golang-*`            | `registry.redhat.io/ubi10/go-toolset:10.1`         |
+| `openshift/Dockerfile` (runtime)                   | `registry.ci.openshift.org/ocp/4.22:base-rhel9`                    | `registry.redhat.io/ubi10/ubi:10.1`                |
+| `openshift/Dockerfile.requirements`                | `registry.ci.openshift.org/ocp/4.22:base-rhel9`                    | `registry.redhat.io/ubi10/ubi:10.1`                |
+| `openshift/release/ansible/Dockerfile.collections` | `registry.ci.openshift.org/ocp/4.22:base-rhel9`                    | `registry.redhat.io/ubi10/ubi:10.1`                |
+
+## Exclusions
+
+- `openshift/ci/dockerfiles/ansible-e2e.Dockerfile` — builds `FROM openshift-ansible-operator-plugins` (CI-internal); no base image to change.
+- `testdata/memcached-molecule-operator/Dockerfile` — uses `quay.io/operator-framework/ansible-operator:dev`; not in scope.
+
+## Prerequisite
+
+PR1 (`rhcos10-ubi9-compat-test`) should pass CI on RHCOS10 nodes before merging this.
+
+## Test Checklist
+
+- [ ] `e2e-ansible`
+- [ ] `e2e-ansible-fips`
+- [ ] `e2e-ansible-rhcos10`
+- [ ] `e2e-ansible-rhcos10-fips`
+
+## CI Image References
+
+```text
+registry.access.redhat.com/ubi9/ubi-minimal:9.7
+→
+registry.redhat.io/ubi10/ubi-minimal:10.1
+
+registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+→
+registry.redhat.io/ubi10/go-toolset:10.1
+
+registry.ci.openshift.org/ocp/4.22:base-rhel9
+→
+registry.redhat.io/ubi10/ubi:10.1
+```

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -2,7 +2,7 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS basebuilder
+FROM registry.redhat.io/ubi10/ubi-minimal:10.1 AS basebuilder
 
 # Install Rust so that we can ensure backwards compatibility with installing/building the cryptography wheel across all platforms
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -35,7 +35,7 @@ RUN set -e && microdnf clean all && rm -rf /var/cache/dnf/* \
   && microdnf clean all \
   && rm -rf /var/cache/dnf
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS base
+FROM registry.redhat.io/ubi10/ubi-minimal:10.1 AS base
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.

--- a/images/ansible-operator/pipfile.Dockerfile
+++ b/images/ansible-operator/pipfile.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS basebuilder
+FROM registry.redhat.io/ubi10/ubi-minimal:10.1 AS basebuilder
 
 # Install Rust so that we can ensure backwards compatibility with installing/building the cryptography wheel across all platforms
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.redhat.io/ubi10/go-toolset:10.1 AS builder
 
+USER root
+
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
 

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -38,10 +38,35 @@ COPY ${REMOTE_SOURCES} ${REMOTE_SOURCES_DIR}
 # Copy our local ansible-runner-http replacement module
 COPY images/ansible-operator/ansible_runner_http /ansible_runner_http
 COPY openshift/install-ansible.sh .
-# ubi10/ubi:10.1 ships python3-urllib3 as an RPM-managed package; pip cannot
-# upgrade it because there is no RECORD file. Remove it first so pip can install
-# the version pinned in requirements.txt.
-RUN rpm -e --nodeps python3-urllib3 \
+# ubi10/ubi:10.1 ships many Python packages as RPM-managed installs that have
+# no pip RECORD file, causing pip to fail when requirements.txt pins different
+# versions. Remove all potentially conflicting RPM Python packages upfront so
+# pip can install the pinned versions cleanly. Uses || true per package so the
+# step succeeds even if a package is not present in the base image.
+RUN for pkg in \
+        python3-urllib3 \
+        python3-six \
+        python3-requests \
+        python3-idna \
+        python3-certifi \
+        python3-charset-normalizer \
+        python3-chardet \
+        python3-resolvelib \
+        python3-pyyaml \
+        python3-pyasn1 \
+        python3-pyasn1-modules \
+        python3-oauthlib \
+        python3-markupsafe \
+        python3-jinja2 \
+        python3-packaging \
+        python3-dateutil \
+        python3-pexpect \
+        python3-ptyprocess \
+        python3-lockfile \
+        python3-rsa \
+        python3-websocket-client; do \
+        rpm -e --nodeps "$pkg" 2>/dev/null || true; \
+    done \
     && chmod +x /install-ansible.sh \
     && ./install-ansible.sh
 

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -38,7 +38,11 @@ COPY ${REMOTE_SOURCES} ${REMOTE_SOURCES_DIR}
 # Copy our local ansible-runner-http replacement module
 COPY images/ansible-operator/ansible_runner_http /ansible_runner_http
 COPY openshift/install-ansible.sh .
-RUN chmod +x /install-ansible.sh \
+# ubi10/ubi:10.1 ships python3-urllib3 as an RPM-managed package; pip cannot
+# upgrade it because there is no RECORD file. Remove it first so pip can install
+# the version pinned in requirements.txt.
+RUN rpm -e --nodeps python3-urllib3 \
+    && chmod +x /install-ansible.sh \
     && ./install-ansible.sh
 
 # Remove packages which are only needed for cachito

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:10.1 AS builder
 
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
@@ -9,7 +9,7 @@ RUN cd /go/src/github.com/openshift/ansible-operator-plugins \
     && export GIT_VERSION="$(make -pRrq --no-print-directory | grep '^IMAGE_VERSION' | awk -F'= ' '{print $2}')-ocp" \
     && make -e build
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.redhat.io/ubi10/ubi:10.1
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/openshift/Dockerfile.requirements
+++ b/openshift/Dockerfile.requirements
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.redhat.io/ubi10/ubi:10.1
 
 RUN set -e && dnf clean all && rm -rf /var/cache/dnf/* \
   && dnf update -y \

--- a/openshift/release/ansible/Dockerfile.collections
+++ b/openshift/release/ansible/Dockerfile.collections
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.redhat.io/ubi10/ubi:10.1
 
 RUN set -e && dnf clean all && rm -rf /var/cache/dnf/* \
   && dnf update -y \

--- a/openshift/requirements-build.txt
+++ b/openshift/requirements-build.txt
@@ -27,6 +27,7 @@ packaging==26.0
     #   -r requirements-build.in
     #   hatchling
     #   setuptools-scm
+    #   vcs-versioning
     #   wheel
 pathspec==1.0.4
     # via
@@ -38,18 +39,22 @@ pluggy==1.6.0
     # via
     #   -r requirements-build.in
     #   hatchling
-poetry-core==2.3.1
+poetry-core==2.3.2
     # via -r requirements-build.in
 semver==3.0.4
     # via
     #   -r requirements-build.in
     #   changelog-chug
-setuptools-scm==9.2.2
+setuptools-scm==10.0.5
     # via hatch-vcs
 trove-classifiers==2026.1.14.14
     # via
     #   -r requirements-build.in
     #   hatchling
+vcs-versioning==1.1.1
+    # via
+    #   -r requirements-build.in
+    #   setuptools-scm
 wheel==0.46.3
     # via -r requirements-build.in
 


### PR DESCRIPTION
## Summary

Migrate all container base images from UBI9/RHEL9 to UBI10/RHEL10 for native RHCOS10 compatibility.
Also moves the registry from `registry.access.redhat.com` to `registry.redhat.io`.

| Image | Before | After |
| --- | --- | --- |
| `images/ansible-operator/Dockerfile` (basebuilder) | `ubi9/ubi-minimal:9.7` | `ubi10/ubi-minimal:10.1` |
| `images/ansible-operator/Dockerfile` (base) | `ubi9/ubi-minimal:9.7` | `ubi10/ubi-minimal:10.1` |
| `images/ansible-operator/pipfile.Dockerfile` | `ubi9/ubi-minimal:9.7` | `ubi10/ubi-minimal:10.1` |
| `openshift/Dockerfile` (builder) | `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22` | `registry.redhat.io/ubi10/go-toolset:10.1` |
| `openshift/Dockerfile` (runtime) | `registry.ci.openshift.org/ocp/4.22:base-rhel9` | `registry.redhat.io/ubi10/ubi:10.1` |
| `openshift/Dockerfile.requirements` | `registry.ci.openshift.org/ocp/4.22:base-rhel9` | `registry.redhat.io/ubi10/ubi:10.1` |
| `openshift/release/ansible/Dockerfile.collections` | `registry.ci.openshift.org/ocp/4.22:base-rhel9` | `registry.redhat.io/ubi10/ubi:10.1` |

## Prerequisite

PR1 (`rhcos10-ubi9-compat-test`) should pass CI on RHCOS10 nodes before merging this.