### PR TITLE
ART-22058: Discover transitive build deps missed by pip_find_builddeps.py

### DIFF
--- a/openshift/Dockerfile.requirements
+++ b/openshift/Dockerfile.requirements
@@ -35,6 +35,13 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip==26.1.2
 #   3. Collects per-package build-system requirements via pip_find_builddeps.py.
 #   4. Detects version conflicts across all build deps using pip-compile + error
 #      parsing and splits conflicting packages into ordered installation phases.
+#   4b. Closes the *transitive* build-dep graph: packages pulled into a build
+#      phase only as a dependency-of-a-dependency (e.g. trove-classifiers, via
+#      hatchling) are never scanned by pip_find_builddeps.py in step 3. Their
+#      own build-system requirements (e.g. calver, needed to build
+#      trove-classifiers from source under Hermeto's source-only pip prefetch
+#      mode) are fetched directly from each package's sdist pyproject.toml and
+#      injected, iterating to a fixed point.
 #   5. Produces requirements-pre-build.txt, requirements-build1.txt,
 #      requirements-build.txt, and requirements.txt with RPM-installed packages
 #      (cryptography, cffi, pycparser, maturin) commented out in every file.

--- a/openshift/hack/generate_requirements.md
+++ b/openshift/hack/generate_requirements.md
@@ -87,6 +87,13 @@ Stage 4  │  Conflict detection + phase splitting  →  3 build .txt files
          │    (e.g. wheel==0.45.1 from ansible-core's pyproject.toml)
          │    and injects them into pre-build; later phases resolve newer versions
          │
+Stage 4b │  Close transitive build-dep graph (sdist pyproject.toml)  →  patched
+         │  ↳ Packages pip-compile pulled in only as a dependency-of-a-dependency
+         │    (e.g. trove-classifiers, via hatchling) were never scanned by
+         │    pip_find_builddeps.py; their own build-system requirements
+         │    (e.g. calver) are fetched directly and injected, iterating to a
+         │    fixed point
+         │
 Stage 5  │  Safety CVE scan of build files  →  auto-fix or FAIL
          │
 Stage 6  │  Verify every Pipfile.lock package is in requirements.txt
@@ -388,6 +395,100 @@ When a single-package phase fails to compile, the script:
 
 ---
 
+## Stage 4b — Transitive Build-Dependency Closure
+
+### The Problem: Second-Order Build Tools
+
+Stage 3 runs `pip_find_builddeps.py` on every package in `pip freeze --all` —
+i.e. every **runtime** package pinned in `Pipfile.lock`. But the compiled
+build requirements files also end up containing packages that were pulled in
+purely as a *runtime dependency of a build tool*, never scanned by Stage 3 at
+all. For example: `ansible-core`'s build system needs `hatch-vcs`, which
+depends on `hatchling`, which in turn depends on `trove-classifiers` — a pure
+metadata package with no build deps of its own that anyone actually calls
+Stage 3 on.
+
+Most of the time this doesn't matter, because most such packages don't need
+anything extra to build. But some do. `trove-classifiers`' own
+`pyproject.toml` declares:
+
+```toml
+[build-system]
+requires = ["setuptools", "calver"]
+```
+
+`calver` is a setuptools plugin that computes `trove-classifiers`' own
+calendar-based version at build time — nothing in `requirements-build.txt`
+would ever reference it unless something specifically goes looking.
+
+### Why `pip_find_builddeps.py` Can't Find It Either
+
+Even running `pip_find_builddeps.py` directly on `trove-classifiers` wouldn't
+help. It relies on pip's own dependency-report machinery, and per
+[pypa/pip#7863][pip-7863], **pip does not surface a package's `[build-system]
+requires` when a compatible wheel is already available** — pip just installs
+the wheel and never invokes the build backend, so the requirement is
+invisible to any tool built on top of pip's reporting.
+
+That would be a non-issue for a normal (non-hermetic) `pip install` — except
+Hermeto (Cachi2), the tool ART/Konflux uses to prefetch dependencies for the
+network-isolated hermetic build, **defaults to source-only prefetching**: no
+binary wheels are fetched for *any* package, so every package — including
+ones with a perfectly good wheel — is built from its sdist inside the
+hermetic sandbox, invoking its `[build-system] requires` regardless. If that
+requirement wasn't prefetched, the build fails with:
+
+```
+Collecting setuptools
+  Using cached setuptools-82.0.1-py3-none-any.whl
+ERROR: Could not find a version that satisfies the requirement calver (from versions: none)
+```
+
+[pip-7863]: https://github.com/pypa/pip/issues/7863
+
+### The Fix: Read `pyproject.toml` Directly
+
+`_pyproject_build_system_requires(name, version)` sidesteps pip's blind spot
+entirely by fetching the package's `pyproject.toml` straight from its sdist on
+PyPI and parsing `[build-system].requires` with `tomllib` — no pip involved,
+so the wheel-availability shortcut never applies.
+
+`stage4b_close_transitive_build_deps()` uses this to iteratively close the
+build-dependency graph:
+
+```
+LOOP (up to 5 passes, converges in 1-2 in practice):
+  for each build phase file (pre-build / build1 / build):
+    resolved = packages actually pinned in the compiled .txt
+    new      = resolved packages not yet probed (by Stage 3 or a prior pass)
+    for each new package:
+      requires = fetch its own [build-system].requires from its sdist
+      for each requirement not already pinned somewhere in this phase:
+        queue it as an addition
+    if any additions were queued:
+      append them to the phase's .in file and re-run pip-compile
+STOP when a full pass finds nothing new
+```
+
+Newly-discovered packages from one pass (e.g. `calver` itself) are re-probed
+in the next pass, so a chain of missing build deps (A needs B, B needs C)
+resolves fully rather than stopping after one hop — this is exactly the same
+one-hop limitation `pip_find_builddeps.py` already has for *first*-order
+packages (see Step 4 of `split_phases()` above), just applied recursively
+instead of being a known, accepted gap.
+
+If an injected requirement's environment marker doesn't apply to the Python
+version generating requirements (e.g. `tomli; python_version < "3.11"` under
+Python 3.12), pip-compile correctly omits it from the compiled output —
+the addition is still tried, it just resolves to "nothing needed here."
+
+This is entirely automatic and package-agnostic: no `calver`-specific
+knowledge is hardcoded anywhere in the script. If a future package pulled in
+transitively needs some other undeclared-to-pip build tool, this stage
+discovers and pins it the same way, without a script change.
+
+---
+
 ## Stage 5 — Build Dependency CVE Scanning
 
 After generating all build files, Safety is used to scan each one for known
@@ -448,14 +549,17 @@ remainder compiles).
 
 In a full local run of the current Pipfile (`make -f openshift/Makefile
 generate-requirements`, ~30 runtime packages, 27 of which needed build-dep
-collection), the entire script — Stages 1 through 6 — completed in well under
-5 minutes; the dnf/toolchain setup portion of the Docker build (cached in
-normal iterative use) is separate from this and unaffected by the script
-itself. In a network-restricted environment, `pip_find_builddeps.py` can fail
-per-package (skipped with a warning, as designed) which shortens Stage 3 but
-produces incomplete build-dep data — this only affects Stage 4's output, not
-the runtime `requirements.txt` from Stages 1/2/6, which involves no per-package
-network calls beyond the initial `pipenv install`/`pip freeze`.
+collection), the entire script — Stages 1 through 6, including 4b — completed
+in well under 5 minutes; the dnf/toolchain setup portion of the Docker build
+(cached in normal iterative use) is separate from this and unaffected by the
+script itself. In a network-restricted environment, `pip_find_builddeps.py`
+can fail per-package (skipped with a warning, as designed) which shortens
+Stage 3 but produces incomplete build-dep data — this only affects Stage 4's
+output, not the runtime `requirements.txt` from Stages 1/2/6, which involves
+no per-package network calls beyond the initial `pipenv install`/`pip freeze`.
+Stage 4b adds its own per-package PyPI/sdist round-trips (one per
+newly-discovered package per pass), but in practice only a handful of
+packages are ever newly-discovered, and it converges in 1-2 passes.
 
 ---
 
@@ -468,6 +572,7 @@ network calls beyond the initial `pipenv install`/`pip freeze`.
 | `_read_pinned(text)` | Parse pip-freeze/pip-compile output → `{norm: "Pkg==ver"}` |
 | `_comment_out(text, norms)` | Prefix matching `pkg==` lines with `#` |
 | `_normalize_quirks(text)` | Fix `python-dateutil==2.9.0.post0` → `2.9.0` |
+| `_pyproject_build_system_requires(name, ver)` | Fetch `[build-system].requires` directly from a package's sdist `pyproject.toml` on PyPI, bypassing pip's [issue #7863][pip-7863] blind spot (Stage 4b) |
 | `_strip_ansi(text)` | Remove terminal colour codes from Safety output |
 | `_parse_vuln_report(text)` | Parse Safety text into `[{package, version, vuln_id, affected_spec}]` |
 | `_min_safe_version(spec)` | Extract fix version from `"<X.Y.Z"` Safety spec |

--- a/openshift/hack/generate_requirements.py
+++ b/openshift/hack/generate_requirements.py
@@ -27,6 +27,23 @@ Stage 4 — Detect version conflicts across all build-dep sets by attempting
            build deps require the *older* version of a conflicting dep go into
            an earlier phase) with bisection fallback.  Map discovered phases to
            the three output files and compile each.
+Stage 4b — Close the *transitive* build-dep graph: packages that pip-compile
+           pulled into a build phase only as a dependency-of-a-dependency
+           (e.g. trove-classifiers, resolved because hatchling needs it) were
+           never scanned by pip_find_builddeps.py in Stage 3, which only runs
+           on Pipfile.lock's runtime packages. Some of these have their own
+           exact build-system requirements that pip_find_builddeps.py cannot
+           discover even if it were run on them directly, because it relies on
+           pip's dependency-report machinery, which does not surface a
+           package's [build-system] requires when a compatible wheel already
+           exists (https://github.com/pypa/pip/issues/7863) — yet Hermeto's
+           hermetic pip prefetcher defaults to source-only mode, so every
+           package is actually built from its sdist regardless of wheel
+           availability. This stage fetches each newly-resolved package's
+           pyproject.toml directly from its sdist and injects any undeclared
+           build-system requirement (e.g. calver, required to build
+           trove-classifiers from source) into the owning phase, iterating to
+           a fixed point.
 Stage 5 — Scan every generated build requirements file for CVEs and attempt to
            auto-fix them.  Exits non-zero if any CVE cannot be auto-fixed, so
            the failure can't be missed in build logs.
@@ -50,11 +67,17 @@ Prerequisites
 from __future__ import annotations
 
 import argparse
+import io
+import json
 import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
+import tomllib
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -170,6 +193,69 @@ def _normalize_quirks(text: str) -> str:
         text,
     )
     return text
+
+
+def _pyproject_build_system_requires(name: str, version: str) -> list[str]:
+    """
+    Fetch a package's OWN `[build-system] requires` directly from its sdist's
+    pyproject.toml on PyPI, bypassing pip entirely.
+
+    pip_find_builddeps.py (Stage 3) discovers build-system requirements via
+    pip's own dependency-report machinery, which does not surface a package's
+    build-system requirements when a compatible wheel is already available —
+    pip simply installs the wheel and never invokes the build backend
+    (https://github.com/pypa/pip/issues/7863). Hermeto/Cachi2 defaults to
+    *source-only* prefetching for pip (no wheels at all), so every package —
+    even ones with wheels — gets built from its sdist inside the hermetic
+    sandbox, invoking its build-system requirements regardless. Reading
+    pyproject.toml directly sidesteps pip's blind spot.
+
+    Returns [] on any failure (no sdist, no pyproject.toml, no [build-system]
+    table, network error, etc.) — a missing result here just means "nothing
+    new to add", not "this package needs nothing" (the legacy PEP 517 default
+    of setuptools+wheel is already present in every phase).
+    """
+    try:
+        url = f"https://pypi.org/pypi/{name}/{version}/json"
+        with urllib.request.urlopen(url, timeout=20) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, ValueError) as e:
+        print(f"    WARNING: could not fetch PyPI metadata for {name}=={version}: {e}", file=sys.stderr)
+        return []
+
+    sdist_url = next(
+        (u["url"] for u in data.get("urls", []) if u.get("packagetype") == "sdist"),
+        None,
+    )
+    if not sdist_url:
+        return []
+
+    try:
+        with urllib.request.urlopen(sdist_url, timeout=60) as resp:
+            raw = resp.read()
+        tf = tarfile.open(fileobj=io.BytesIO(raw))
+    except (urllib.error.URLError, TimeoutError, tarfile.TarError) as e:
+        print(f"    WARNING: could not download/open sdist for {name}=={version}: {e}", file=sys.stderr)
+        return []
+
+    with tf:
+        # The sdist's pyproject.toml lives at the top level of its single
+        # top-level directory, e.g. "trove_classifiers-2026.6.1.19/pyproject.toml".
+        member = next(
+            (m for m in tf.getmembers()
+             if m.name.endswith("pyproject.toml") and m.name.count("/") <= 1),
+            None,
+        )
+        if member is None:
+            return []
+        try:
+            content = tf.extractfile(member).read()
+            parsed = tomllib.loads(content.decode("utf-8"))
+        except (tomllib.TOMLDecodeError, UnicodeDecodeError, AttributeError):
+            return []
+
+    requires = parsed.get("build-system", {}).get("requires", [])
+    return [str(r) for r in requires]
 
 
 def _strip_ansi(text: str) -> str:
@@ -1046,6 +1132,120 @@ def stage4_build_phases(
 
 
 # ---------------------------------------------------------------------------
+# Stage 4b — Close the transitive build-dependency graph
+# ---------------------------------------------------------------------------
+
+
+def stage4b_close_transitive_build_deps(
+    out_dir: Path,
+    scanned: set[str],
+    max_iterations: int = 5,
+) -> None:
+    """
+    Close the build-dependency graph for packages that appear in a compiled
+    requirements-build*.txt file only as a TRANSITIVE dependency of a package
+    Stage 3 actually scanned (e.g. trove-classifiers, pulled in solely because
+    hatchling needs it). Stage 3 never runs pip_find_builddeps.py on these —
+    it only scans Pipfile.lock's runtime packages — so their own build-system
+    requirements (declared in *their* pyproject.toml) are otherwise never
+    discovered. See _pyproject_build_system_requires() for why
+    pip_find_builddeps.py itself cannot fill this gap even if pointed at them
+    directly.
+
+    Repeatedly, for each build phase file:
+      1. Parse the compiled .txt for its resolved {pkg: version} set.
+      2. For every resolved package not yet probed, fetch its OWN
+         [build-system] requires directly from its sdist's pyproject.toml.
+      3. Any requirement whose package isn't already pinned somewhere in that
+         phase is appended to the phase's .in file, which is then recompiled.
+    Stops when a full pass discovers nothing new, or after max_iterations
+    passes (safety valve — a normal run converges in 1-2 passes).
+    """
+    print("\n══ Stage 4b: Close transitive build-dep graph (sdist pyproject.toml) ══")
+
+    phases = [
+        ("requirements-pre-build", "pre-build"),
+        ("requirements-build1", "build1"),
+        ("requirements-build", "build"),
+    ]
+    rpm_norms = {_norm(p) for p in RPM_INSTALLED}
+    probed: set[str] = set(scanned)
+
+    for iteration in range(1, max_iterations + 1):
+        print(f"\n  Pass {iteration}:")
+        any_new = False
+
+        for base, label in phases:
+            txt_path = out_dir / f"{base}.txt"
+            in_path = out_dir / f"{base}.in"
+            if not txt_path.exists() or not in_path.exists():
+                continue
+
+            resolved = _read_pinned(txt_path.read_text())
+            new_pkgs = {n: v for n, v in resolved.items() if n not in probed}
+            if not new_pkgs:
+                continue
+
+            print(
+                f"    {label}: probing {len(new_pkgs)} newly-resolved"
+                f" package(s) not covered by Stage 3: {sorted(new_pkgs)}"
+            )
+
+            additions: list[str] = []
+            queued_norms: set[str] = set()
+            for norm, pkg_line in sorted(new_pkgs.items()):
+                probed.add(norm)
+                pkg_name, pkg_version = pkg_line.split("==", 1)
+                requires = _pyproject_build_system_requires(pkg_name, pkg_version)
+                for req in requires:
+                    m = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", req.strip())
+                    if not m:
+                        continue
+                    req_norm = _norm(m.group(1))
+                    if req_norm in resolved or req_norm in queued_norms:
+                        continue  # already pinned in this phase, or already queued below
+                    additions.append(req.strip())
+                    queued_norms.add(req_norm)
+                    print(
+                        f"      + {req.strip()}  (build-system requirement of"
+                        f" {pkg_name}=={pkg_version}, undetected by"
+                        " pip_find_builddeps.py — see pypa/pip#7863)"
+                    )
+
+            if not additions:
+                continue
+
+            original_in = in_path.read_text()
+            in_path.write_text(original_in.rstrip("\n") + "\n" + "\n".join(additions) + "\n")
+            ok, stderr = _pip_compile(in_path, txt_path, ["--allow-unsafe"])
+            if not ok:
+                print(
+                    f"    WARNING: pip-compile failed after injecting"
+                    f" {additions} into {label}; reverting:\n{stderr}",
+                    file=sys.stderr,
+                )
+                in_path.write_text(original_in)
+                continue
+
+            any_new = True
+            content = _normalize_quirks(txt_path.read_text())
+            content = _comment_out(content, rpm_norms)
+            txt_path.write_text(content)
+            print(f"    → {txt_path.name} recompiled ({len(content.splitlines())} lines)")
+
+        if not any_new:
+            print("  No new transitive build deps discovered — closure complete.")
+            break
+    else:
+        print(
+            f"  WARNING: reached max_iterations={max_iterations} without a"
+            " pass discovering nothing new; re-run generate_requirements.py"
+            " if newly-added packages keep introducing further build deps.",
+            file=sys.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Stage 5 — CVE checking for build requirements files
 # ---------------------------------------------------------------------------
 
@@ -1395,6 +1595,10 @@ def main() -> None:
 
         # Stage 4 — detect conflicts, split phases, compile build files
         stage4_build_phases(pkg_constraints, out_dir, tmp)
+
+        # Stage 4b — close the transitive build-dep graph (e.g. calver, needed
+        # to build trove-classifiers from source but invisible to Stage 3)
+        stage4b_close_transitive_build_deps(out_dir, set(pkg_constraints.keys()))
 
         # Stage 5 — check generated build requirements for CVEs and auto-fix
         stage5_check_build_dep_cves(out_dir, tmp)

--- a/openshift/requirements-build.txt
+++ b/openshift/requirements-build.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --allow-unsafe --output-file=/requirements-build.txt --strip-extras /requirements-build.in
 #
+calver==2025.10.20
+    # via -r /requirements-build.in
 #cffi==2.1.1
     # via -r /requirements-build.in
 changelog-chug==0.0.3
@@ -18,7 +20,7 @@ flit-core==3.12.0
     # via -r /requirements-build.in
 hatch-vcs==0.5.0
     # via -r /requirements-build.in
-hatchling==1.31.0
+hatchling==1.32.0
     # via
     #   -r /requirements-build.in
     #   hatch-vcs
@@ -41,6 +43,8 @@ pluggy==1.6.0
     # via
     #   -r /requirements-build.in
     #   hatchling
+poetry-core==2.4.1
+    # via -r /requirements-build.in
 #pycparser==3.0
     # via
     #   -r /requirements-build.in
@@ -59,15 +63,19 @@ setuptools-scm==10.2.1
     # via
     #   -r /requirements-build.in
     #   hatch-vcs
+tomlkit==0.15.1
+    # via
+    #   -r /requirements-build.in
+    #   hatchling
 trove-classifiers==2026.6.1.19
     # via
     #   -r /requirements-build.in
     #   hatchling
-vcs-versioning==2.2.3
+vcs-versioning==2.2.4
     # via
     #   -r /requirements-build.in
     #   setuptools-scm
-wheel==0.47.0
+wheel==0.48.0
     # via -r /requirements-build.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Summary

The ART hermetic build for `openshift-enterprise-ansible-operator` has been failing since Aug 10 (9 consecutive `build_error` runs) with:

```
Collecting setuptools
  Using cached setuptools-82.0.1-py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement calver
```

**Root cause:** `trove-classifiers` (pulled into `requirements-build.txt` only as a transitive dependency of `hatchling`) declares `calver` in its own `pyproject.toml` `[build-system].requires`. `pip_find_builddeps.py` never scans it — Stage 3 of `generate_requirements.py` only runs on `Pipfile.lock`'s runtime packages, not on second-order build tools pulled in by `pip-compile`. Even pointed at it directly, `pip_find_builddeps.py` couldn't discover this, since it relies on pip's own dependency-report machinery, which doesn't surface `[build-system]` requirements for a package that already has a wheel ([pypa/pip#7863](https://github.com/pypa/pip/issues/7863)). Hermeto/Cachi2 defaults to *source-only* prefetching, so every package — wheel or not — is actually built from its sdist inside the hermetic sandbox, invoking that requirement regardless.

**Fix:** Add Stage 4b to `generate_requirements.py`. After phase-splitting, it iteratively fetches each newly-resolved (previously unscanned) package's `pyproject.toml` directly from its sdist on PyPI — bypassing pip entirely — and injects any undeclared build-system requirement into the owning phase, converging to a fixed point. This is fully dynamic (no package names hardcoded), so it will catch the same class of gap for any future package, not just `calver`/`trove-classifiers`.

- `openshift/hack/generate_requirements.py`: new `_pyproject_build_system_requires()` helper and `stage4b_close_transitive_build_deps()` stage, wired in after Stage 4.
- `openshift/hack/generate_requirements.md`: new "Stage 4b" section documenting the problem and fix.
- `openshift/Dockerfile.requirements`: updated stage comment list.
- `openshift/requirements-build.txt`: regenerated — adds `calver==2025.10.20` (the fix) and `poetry-core` (needed to build `hatchling`'s new `tomlkit` dependency from source); other changes are routine `pip-compile` version drift (`hatchling`/`wheel`/`vcs-versioning` bumps) unrelated to this fix.

## Test plan

- [x] Unit-tested `_pyproject_build_system_requires` directly against `trove-classifiers` (returns `['setuptools', 'calver']`) and edge cases (missing package, no `[build-system]` table).
- [x] Isolated integration test with a real `pip-tools` venv reproduced the bug (hatchling → trove-classifiers with no `calver`) and confirmed Stage 4b's loop discovers and injects it correctly.
- [x] Full end-to-end `make -f openshift/Makefile generate-requirements` run (fresh `--no-cache` container build): Stage 4b fires twice, adds `calver`/`poetry-core`, converges cleanly; Stage 5/6 pass with no warnings.
- [x] Diff against committed files is minimal: only `requirements-build.txt` changed (the new packages plus expected drift); `requirements.txt`, `requirements-pre-build.txt`, `requirements-build1.txt`, `Pipfile.lock` untouched.
- [x] `go build ./...` and `go vet ./...` pass (no Go code touched).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Build requirements generation now discovers transitive build dependencies automatically.
  - Requirements are iteratively updated until the dependency set is complete, with safeguards for convergence and recoverable failures.

- **Documentation**
  - Added guidance describing the expanded generation workflow, performance considerations, and dependency discovery behavior.

- **Chores**
  - Updated build tooling dependencies and versions to support the enhanced requirements-generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->